### PR TITLE
Set AccessibilityTitle option properly

### DIFF
--- a/src/VisualStudioUI.VSMac/Options/ButtonOptionVSMac.cs
+++ b/src/VisualStudioUI.VSMac/Options/ButtonOptionVSMac.cs
@@ -27,8 +27,6 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
                     _button.Font = NSFont.SystemFontOfSize(NSFont.SystemFontSize);
                     _button.Title = ButtonOption.ButtonLabel;
                     _button.TranslatesAutoresizingMaskIntoConstraints = false;
-                    _button.AccessibilityTitle = "Control";
-                    _button.AccessibilityHelp = "Provides a control";
                     _button.SizeToFit();
                 }
 

--- a/src/VisualStudioUI.VSMac/Options/CheckBoxOptionVSMac.cs
+++ b/src/VisualStudioUI.VSMac/Options/CheckBoxOptionVSMac.cs
@@ -30,8 +30,6 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
                     _button.Font = NSFont.SystemFontOfSize(NSFont.SystemFontSize);
                     _button.Title = CheckBoxOption.ButtonLabel;
                     _button.TranslatesAutoresizingMaskIntoConstraints = false;
-                    _button.AccessibilityTitle = "Control";
-                    _button.AccessibilityHelp = "Provides a control";
                     _button.State = CheckBoxOption.Property.Value ? NSCellStateValue.On : NSCellStateValue.Off;
 
                     property.PropertyChanged += delegate

--- a/src/VisualStudioUI.VSMac/Options/ComboBoxOptionVSMac.cs
+++ b/src/VisualStudioUI.VSMac/Options/ComboBoxOptionVSMac.cs
@@ -34,6 +34,7 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
                         Font = NSFont.SystemFontOfSize(NSFont.SystemFontSize),
                         TranslatesAutoresizingMaskIntoConstraints = false
                     };
+                    SetAccessibilityTitleToLabel(_popUpButton);
 
                     _popUpButton.WidthAnchor.ConstraintEqualToConstant(198f).Active = true;
 

--- a/src/VisualStudioUI.VSMac/Options/DirectoryOptionVSMac.cs
+++ b/src/VisualStudioUI.VSMac/Options/DirectoryOptionVSMac.cs
@@ -41,6 +41,7 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
                         Bordered = true,
                         DrawsBackground = true,
                     };
+                    SetAccessibilityTitleToLabel(_textField);
 
                     _controlView.AddArrangedSubview(_textField);
 

--- a/src/VisualStudioUI.VSMac/Options/EditableComboBoxOptionVSMac.cs
+++ b/src/VisualStudioUI.VSMac/Options/EditableComboBoxOptionVSMac.cs
@@ -29,6 +29,7 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
                         Font = NSFont.SystemFontOfSize(NSFont.SystemFontSize),
                         TranslatesAutoresizingMaskIntoConstraints = false
                     };
+                    SetAccessibilityTitleToLabel(_comboBox);
 
                     _comboBox.WidthAnchor.ConstraintEqualToConstant(198f).Active = true;
 

--- a/src/VisualStudioUI.VSMac/Options/OptionVSMac.cs
+++ b/src/VisualStudioUI.VSMac/Options/OptionVSMac.cs
@@ -162,5 +162,12 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
                     return 0;
             }
         }
+
+        protected void SetAccessibilityTitleToLabel(NSView control, string? labelOverride = null)
+        {
+            string? label = labelOverride ?? Option.Label;
+            if (label != null && label.Length > 0)
+                control.AccessibilityTitle = label;
+        }
     }
 }

--- a/src/VisualStudioUI.VSMac/Options/OptionWithLeftLabelVSMac.cs
+++ b/src/VisualStudioUI.VSMac/Options/OptionWithLeftLabelVSMac.cs
@@ -38,9 +38,6 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
             _optionView.WidthAnchor.ConstraintEqualToConstant(600f - IndentValue()).Active = true;
 
             _control = ControlView;
-            // TODO: Set a11y info properly
-            _control.AccessibilityLabel = "Control";
-            _control.AccessibilityHelp = "Provides a control";
 
             _optionView.AddSubview(_control);
 
@@ -101,8 +98,8 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
 
             _optionView!.AddSubview(_hintButton);
 
-            _hintButton.LeadingAnchor.ConstraintEqualToAnchor(_control.TrailingAnchor, 10f).Active = true;
-            _hintButton.CenterYAnchor.ConstraintEqualToAnchor(_control.CenterYAnchor).Active = true;
+            _hintButton.LeadingAnchor.ConstraintEqualToAnchor(_control!.TrailingAnchor, 10f).Active = true;
+            _hintButton.CenterYAnchor.ConstraintEqualToAnchor(_control!.CenterYAnchor).Active = true;
         }
     }
 }

--- a/src/VisualStudioUI.VSMac/Options/ProgressIndicatorOptionVSMac.cs
+++ b/src/VisualStudioUI.VSMac/Options/ProgressIndicatorOptionVSMac.cs
@@ -71,6 +71,7 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
             _progressIndicator.ControlSize = NSControlSize.Small;
             _progressIndicator.IsDisplayedWhenStopped = false;
             _progressIndicator.TranslatesAutoresizingMaskIntoConstraints = false;
+            SetAccessibilityTitleToLabel(_progressIndicator);
             _progressIndicator.SizeToFit();
             _optionView.AddSubview(_progressIndicator);
 

--- a/src/VisualStudioUI.VSMac/Options/ProjectFileOptionVSMac.cs
+++ b/src/VisualStudioUI.VSMac/Options/ProjectFileOptionVSMac.cs
@@ -41,6 +41,7 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
                         Bordered = true,
                         DrawsBackground = true,
                     };
+                    SetAccessibilityTitleToLabel(_textField);
 
                     _controlView.AddArrangedSubview(_textField);
 

--- a/src/VisualStudioUI.VSMac/Options/RadioButtonOptionVSMac.cs
+++ b/src/VisualStudioUI.VSMac/Options/RadioButtonOptionVSMac.cs
@@ -30,8 +30,6 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
                     _button.Font = NSFont.SystemFontOfSize(NSFont.SystemFontSize);
                     _button.Title = RadioButtonOption.ButtonLabel;
                     _button.TranslatesAutoresizingMaskIntoConstraints = false;
-                    _button.AccessibilityTitle = "Control";
-                    _button.AccessibilityHelp = "Provides a control";
                     _button.State = RadioButtonOption.Property.Value ? NSCellStateValue.On : NSCellStateValue.Off;
 
                     property.PropertyChanged += delegate

--- a/src/VisualStudioUI.VSMac/Options/ScaledImageFileOptionVSMac.cs
+++ b/src/VisualStudioUI.VSMac/Options/ScaledImageFileOptionVSMac.cs
@@ -62,6 +62,7 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
                 WantsLayer = true,
                 TranslatesAutoresizingMaskIntoConstraints = false
             };
+            SetAccessibilityTitleToLabel(imageView);
             imageView.Layer.BorderColor = NSColor.LightGray.CGColor;
             imageView.Layer.BorderWidth = 1f;
             imageView.Layer.CornerRadius = 4f;

--- a/src/VisualStudioUI.VSMac/Options/StringListOptionVSMac.cs
+++ b/src/VisualStudioUI.VSMac/Options/StringListOptionVSMac.cs
@@ -348,7 +348,5 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
         {
             return _platform.StringListOption.Model.Value.Length;
         }
-
     }
-
 }

--- a/src/VisualStudioUI.VSMac/Options/SwitchOptionVSMac.cs
+++ b/src/VisualStudioUI.VSMac/Options/SwitchOptionVSMac.cs
@@ -42,7 +42,6 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
             _switchButton.ControlSize = NSControlSize.Regular;
             _switchButton.State = enable ? 1 : 0;
             _switchButton.TranslatesAutoresizingMaskIntoConstraints = false;
-            _switchButton.AccessibilityHelp = "Provides a control";
 
             _switchButton.Activated += (s, e) => {
                 ((SwitchOption)Option).Property.Value = (_switchButton.State == 1);
@@ -76,6 +75,8 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
                 buttonLabel = SwitchOption.Label;
             if (buttonLabel == null)
                 buttonLabel = "";
+
+            SetAccessibilityTitleToLabel(_switchButton, buttonLabel);
 
             var title = new NSTextField();
             title.Editable = false;

--- a/src/VisualStudioUI.VSMac/Options/TextOptionVSMac.cs
+++ b/src/VisualStudioUI.VSMac/Options/TextOptionVSMac.cs
@@ -39,8 +39,9 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
                         TranslatesAutoresizingMaskIntoConstraints = false,
                         Editable = TextOption.Editable,
                         Bordered = TextOption.Bordered,
-                        DrawsBackground = TextOption.DrawsBackground
+                        DrawsBackground = TextOption.DrawsBackground,
                     };
+                    SetAccessibilityTitleToLabel(_textField);
 
                     _controlView.AddSubview(_textField);
 
@@ -71,12 +72,10 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
                         _menuBtn.TrailingAnchor.ConstraintEqualToAnchor(_controlView.TrailingAnchor).Active = true;
                         _menuBtn.CenterYAnchor.ConstraintEqualToAnchor(_controlView.CenterYAnchor).Active = true;
                         _controlView.WidthAnchor.ConstraintEqualToConstant(228f).Active = true;
-
                     }
                     else
                     {
                         _controlView.WidthAnchor.ConstraintEqualToConstant(196f).Active = true;
-
                     }
 
                     _controlView.HeightAnchor.ConstraintEqualToConstant(21).Active = true;


### PR DESCRIPTION
Updated to better handle a11y, as follows:
- For option controls that have a Title property (e.g. NSButton normally has a
Title, which is the button label), don't set anything for a11y, so that the title
is read by voice over.
- For option controls that don't have a Title property (e.g. NSTextField), then
set the AccessibilityTitle property to be the label for the control (if there is one).

This handles most of what we want for a11y. There are still a few things missing here,
but this is the bulk of the needed support.