### PR TITLE
fix hint be hide and long string be cut off of checkbox

### DIFF
--- a/examples/StandaloneApp/StandaloneApp/Main.cs
+++ b/examples/StandaloneApp/StandaloneApp/Main.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudioUI.StandaloneApp
                 Label = "Test enable"
             };
 
-            var dependOn = new CheckBoxOption(BoolProp(false)) { ButtonLabel = "enable" };
+            var dependOn = new CheckBoxOption(BoolProp(false)) { ButtonLabel = "Выполнять все 32-разрядные операции с плавающей запятой как 64-разрядные" };
 
             var warning = new ViewModelProperty<Message?>("", new Message("warning", MessageSeverity.Warning));
             warning.Bind();

--- a/src/VisualStudioUI.VSMac/Options/CheckBoxOptionVSMac.cs
+++ b/src/VisualStudioUI.VSMac/Options/CheckBoxOptionVSMac.cs
@@ -1,5 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System.Text;
 using AppKit;
 using Microsoft.VisualStudioUI.Options;
 using Microsoft.VisualStudioUI.Options.Models;
@@ -32,6 +33,29 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
                     _button.TranslatesAutoresizingMaskIntoConstraints = false;
                     _button.State = CheckBoxOption.Property.Value ? NSCellStateValue.On : NSCellStateValue.Off;
 
+                    var maxLength = 77; 
+                    if (_button.Title.Length > (maxLength/2) && !_button.Title.Contains("\n"))
+                    {
+                        // Handle long strings of different language without inserted "\n"
+                        var charLength = Encoding.UTF8.GetByteCount(_button.Title);
+                        if (charLength > _button.Title.Length)
+                        {
+                            if ((charLength / _button.Title.Length) > 2)
+                                maxLength = maxLength / 2; // language is double-byte
+                            else
+                                maxLength = (int)(maxLength * 0.75); // the language is mixes with double-byte and single-byte
+                        }
+
+                        if (_button.Title.Length > maxLength)
+                        {
+                            _button.Title = InsertNewLine(_button.Title, maxLength);
+                        }
+                    }
+
+                    _button.Cell.LineBreakMode = NSLineBreakMode.CharWrapping;
+                    _button.SizeToFit();
+                    _button.Cell.Alignment = NSTextAlignment.Left;
+                    
                     property.PropertyChanged += delegate
                     {
                         _button.State = CheckBoxOption.Property.Value ? NSCellStateValue.On : NSCellStateValue.Off;
@@ -40,6 +64,29 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
 
                 return _button!;
             }
+        }
+
+        private string InsertNewLine(string str, int max, int searchStart = 0)
+        {
+            if (str.Length <= max) return str;
+
+            int removeFrom = searchStart > 0 ? searchStart : max;
+
+            var index = str.Remove(removeFrom, str.Length - removeFrom).LastIndexOf(" ");
+            if (index > 0)
+                str = str.Remove(index, 1).Insert(index, "\n");
+            else
+            {
+                index = removeFrom;
+                str = str.Insert(index, "\n");
+            }
+
+            if (str.Remove(0, index).Length > max)
+            {
+                return InsertNewLine(str, max, index + max);
+            }
+
+            return str;
         }
 
         public override void OnEnableChanged(bool enabled)

--- a/src/VisualStudioUI.VSMac/Options/OptionWithLeftLabelVSMac.cs
+++ b/src/VisualStudioUI.VSMac/Options/OptionWithLeftLabelVSMac.cs
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
             float leftSpace = (Option.AllowSpaceForLabel||_label != null) ? 222f : 20f;
             _control.LeadingAnchor.ConstraintEqualToAnchor(_optionView.LeadingAnchor, leftSpace + IndentValue()).Active = true;
             _control.TopAnchor.ConstraintEqualToAnchor(_optionView.TopAnchor, 5f).Active = true;
-
+            _control.TrailingAnchor.ConstraintLessThanOrEqualToAnchor(_optionView.TrailingAnchor, -50f).Active = true;
         }
 
         public override void OnEnableChanged(bool enabled)


### PR DESCRIPTION
[AB#1389448](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1389448): [VSM] The text is cut off on iOS Options page
![image](https://user-images.githubusercontent.com/11625239/132005005-6b6c3623-0ad8-4ede-aa63-f5b8df259534.png)

[AB#1389630](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1389630): [VSM] The icon is cut off on Android Package Signing.
![image](https://user-images.githubusercontent.com/11625239/132004791-f5431ba2-4590-4fa6-a50e-1b32c869e3de.png)
