### PR TITLE
Update Text Option property only allow number input.

### DIFF
--- a/examples/StandaloneApp/StandaloneApp/Main.cs
+++ b/examples/StandaloneApp/StandaloneApp/Main.cs
@@ -43,7 +43,7 @@ namespace Microsoft.VisualStudioUI.StandaloneApp
             card.AddOption(new SeparatorOption());
             card.AddOption(new CheckBoxOption(BoolProp(false)) { ButtonLabel = "test", DisablebilityDependsOn = dependOn });
             card.AddOption(new DocButtonOption(StringProp("test"), "test") { DisablebilityDependsOn = dependOn });
-            card.AddOption(new TextOption(StringProp("")) { Label = "test warning", ValidationMessage = warning, DisablebilityDependsOn = dependOn });
+            card.AddOption(new TextOption(StringProp("")) { Label = "test warning", AllowOnlyNumbers = true, ValidationMessage = warning, DisablebilityDependsOn = dependOn });
             card.AddOption(new TextOption(StringProp("")) { Label = "test error", ValidationMessage = error, DisablebilityDependsOn = dependOn });
             card.AddOption(new DirectoryOption(StringProp("")) { Label = "Choose Firectory", Hint = "hint", DisablebilityDependsOn = dependOn });
             card.AddOption(new ProjectFileOption(StringProp("")) { Label = "Choose File", Hint = "hint" , DisablebilityDependsOn = dependOn });

--- a/src/VisualStudioUI.VSMac/Options/TextOptionVSMac.cs
+++ b/src/VisualStudioUI.VSMac/Options/TextOptionVSMac.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
     public class TextOptionVSMac : OptionWithLeftLabelVSMac
     {
         private NSView? _controlView;
-        private NSTextField? _textField;
+        private MacDebuggerTextField? _textField;
         private NSButton? _menuBtn;
 
         public TextOptionVSMac(TextOption option) : base(option)
@@ -33,12 +33,13 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
 
                     ViewModelProperty<string> property = TextOption.Property;
 
-                    _textField = new NSTextField
+                    _textField = new MacDebuggerTextField
                     {
                         Font = NSFont.SystemFontOfSize(NSFont.SystemFontSize),
                         StringValue = property.Value ?? string.Empty,
                         TranslatesAutoresizingMaskIntoConstraints = false,
                         PlaceholderString = TextOption.PlaceholderText ?? string.Empty,
+                        AllowOnlyNumbers = TextOption.AllowOnlyNumbers,
                     };
                     _textField.LineBreakMode = NSLineBreakMode.TruncatingTail;
                     SetAccessibilityTitleToLabel(_textField);
@@ -51,16 +52,6 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
                     };
 
                     _textField.Changed += delegate { property.Value = _textField.StringValue; };
-
-                    if (TextOption.AllowOnlyNumbers)
-                    {
-                        var format = new NSNumberFormatter()
-                        {
-                            NumberStyle = NSNumberFormatterStyle.None,
-                        };
-
-                        _textField.Formatter = format;
-                    }
 
                     if (TextOption.MacroMenuItems != null)
                     {
@@ -145,6 +136,28 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
             if (_menuBtn!= null)
                 _menuBtn.Enabled = enabled;
         }
+    }
 
+    internal class MacDebuggerTextField : NSTextField
+    {
+        public bool AllowOnlyNumbers { get; set; } = false;
+
+        public override void DidChange(NSNotification notification)
+        {
+            if (AllowOnlyNumbers)
+            {
+                StringValue = StringValue.Trim();
+                if (StringValue.Length > 0)
+                {
+                    var newInput = StringValue[StringValue.Length - 1];
+                    if (!int.TryParse(newInput.ToString(), out int n))
+                    {
+                        StringValue = StringValue.TrimEnd(newInput);
+                    }
+                }
+            }
+
+            base.DidChange(notification);
+        }
     }
 }

--- a/src/VisualStudioUI.VSMac/Options/TextOptionVSMac.cs
+++ b/src/VisualStudioUI.VSMac/Options/TextOptionVSMac.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
     public class TextOptionVSMac : OptionWithLeftLabelVSMac
     {
         private NSView? _controlView;
-        private MacDebuggerTextField? _textField;
+        private CustomTextField? _textField;
         private NSButton? _menuBtn;
 
         public TextOptionVSMac(TextOption option) : base(option)
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
 
                     ViewModelProperty<string> property = TextOption.Property;
 
-                    _textField = new MacDebuggerTextField
+                    _textField = new CustomTextField
                     {
                         Font = NSFont.SystemFontOfSize(NSFont.SystemFontSize),
                         StringValue = property.Value ?? string.Empty,
@@ -138,7 +138,7 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
         }
     }
 
-    internal class MacDebuggerTextField : NSTextField
+    internal class CustomTextField : NSTextField
     {
         public bool AllowOnlyNumbers { get; set; } = false;
 


### PR DESCRIPTION
[Bug 1407134](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/1407125): [VSM] Android run configuration Category window user id input string limit incorrectly