### PR TITLE
Migrate bugs fix

### DIFF
--- a/examples/StandaloneApp/StandaloneApp/Main.cs
+++ b/examples/StandaloneApp/StandaloneApp/Main.cs
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudioUI.StandaloneApp
             card.AddOption(new TextOption(StringProp("")) { Label = "Change the language to Russia and French Chinese Spain", ValidationMessage = warning, DisablebilityDependsOn = dependOn });
             card.AddOption(new TextOption(StringProp("")) { Label = "test error", ValidationMessage = error, DisablebilityDependsOn = dependOn });
             card.AddOption(new DirectoryOption(StringProp("")) { Label = "Choose Firectory", Hint = "hint", DisablebilityDependsOn = dependOn });
-            card.AddOption(new ProjectFileOption(StringProp("")) { Label = "Choose File", Hint = "hint" , DisablebilityDependsOn = dependOn });
+            card.AddOption(new ProjectFileOption(StringProp("/Applications/Xcode13beta5.app")) { Label = "Choose File", Hint = "hint" , DisablebilityDependsOn = dependOn });
             TextOption fileEntry = new TextOption(StringProp(""), "user id")
             {
                 Label = "Uncompressed resource extensions",

--- a/src/VisualStudioUI.VSMac/Options/ComboBoxOptionVSMac.cs
+++ b/src/VisualStudioUI.VSMac/Options/ComboBoxOptionVSMac.cs
@@ -54,7 +54,10 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
                     }
                     else
                     {
-                        itemsProperty.PropertyChanged += delegate { UpdateItemChoices(); };
+                        itemsProperty.PropertyChanged += delegate {
+                            UpdateItemChoices();
+                            UpdateHintButton();
+                        };
 
                         UpdateItemChoices();
                     }
@@ -99,7 +102,6 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
             }
 
             UpdateSelectedItemUIFromProperty();
-
         }
 
         private void UpdateMultipleLevelMenuItemChoices()

--- a/src/VisualStudioUI.VSMac/Options/ProjectFileOptionVSMac.cs
+++ b/src/VisualStudioUI.VSMac/Options/ProjectFileOptionVSMac.cs
@@ -34,12 +34,13 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
 
                     _textField = new NSTextField
                     {
-                        Font = NSFont.SystemFontOfSize(NSFont.SystemFontSize),
+                        Font = NSFont.SystemFontOfSize(NSFont.SmallSystemFontSize),
                         StringValue = property.Value ?? string.Empty,
                         TranslatesAutoresizingMaskIntoConstraints = false,
                         Editable = true,
                         Bordered = true,
                         DrawsBackground = true,
+                        LineBreakMode = NSLineBreakMode.TruncatingTail
                     };
                     SetAccessibilityTitleToLabel(_textField);
 


### PR DESCRIPTION
Fixed:
AB#1407235: [VSM] The renamed Xcode will not be displayed on Location box.
AB#1408742: [VSM] An error message is displayed when clicking the Provisioning profile warning icon on the iOS Bundle Singing page