### PR TITLE
fix Bug 1389630: [VSM] The icon is cut off on Android Package Signing.

### DIFF
--- a/src/VisualStudioUI.VSMac/Options/CheckBoxOptionVSMac.cs
+++ b/src/VisualStudioUI.VSMac/Options/CheckBoxOptionVSMac.cs
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
                     {
                         _button.Font = NSFont.SystemFontOfSize(10);
                     }
-                    else if (_button.Title.Length > 80)
+                    else if (_button.Title.Length > 74)
                     {
                         _button.Font = NSFont.SystemFontOfSize(NSFont.SmallSystemFontSize);
                     } else


### PR DESCRIPTION
fix 1389630: [VSM] The icon is cut off on Android Package Signing.
<img width="665" alt="Screen Shot 2021-10-08 at 11 07 40 AM" src="https://user-images.githubusercontent.com/37265150/136492610-8b791ed4-d2d2-46e3-bee6-5d022cc36cae.png">
