### PR TITLE
Protect against NRE

### DIFF
--- a/src/VisualStudioUI.VSMac/Options/TextOptionVSMac.cs
+++ b/src/VisualStudioUI.VSMac/Options/TextOptionVSMac.cs
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
 
                     property.PropertyChanged += delegate
                     {
-                        _textField.StringValue = TextOption.Property.Value;
+                        _textField.StringValue = TextOption.Property.Value ?? string.Empty;
                     };
 
                     _textField.Changed += delegate { property.Value = _textField.StringValue; };


### PR DESCRIPTION
TextOption view model string values aren't really supposed to
be null - they should be the empty string if not present.
That said, with this change if the value is null we
turn that into the empty string rather than generating
an NRE - that's much safer in general and fixes [AB#1487328](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1487328/)
specifically, where the DataUri can be null.
