### PR TITLE
Update style for buttons below lists

### DIFF
--- a/src/VisualStudioUI.VSMac/Options/BarTextButton.cs
+++ b/src/VisualStudioUI.VSMac/Options/BarTextButton.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using AppKit;
+using Foundation;
+using CoreGraphics;
+
+namespace Microsoft.VisualStudioUI.VSMac.Options
+{
+    /// <summary>
+    /// A BarTextButton is for multiple buttons in a horizontal bar, like Add/Remove buttons
+    /// below lists. It's copied from
+    /// https://github.com/xamarin/vsmac/blob/main/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ButtonBarTextButton.cs
+    /// </summary>
+    class BarTextButton : NSButton
+    {
+        const int ContentMargin = 10;
+        const int MinimumSize = 80;
+
+        public override CGSize IntrinsicContentSize => new CGSize(Math.Max(MinimumSize, base.IntrinsicContentSize.Width + (ContentMargin * 2)), base.IntrinsicContentSize.Height);
+
+        public BarTextButton()
+        {
+            BezelStyle = NSBezelStyle.RoundRect;
+            TranslatesAutoresizingMaskIntoConstraints = false;
+        }
+    }
+}

--- a/src/VisualStudioUI.VSMac/Options/KeyValueTableEntryOptionVSMac.cs
+++ b/src/VisualStudioUI.VSMac/Options/KeyValueTableEntryOptionVSMac.cs
@@ -96,22 +96,15 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
             };
 
             _optionView.AddSubview(scrolledView);
-            _addButton = new NSButton
-            {
-                BezelStyle = NSBezelStyle.RoundRect,
-                Title = KeyValueTableEntryOption.AddButtonTitle,
-                ToolTip = KeyValueTableEntryOption.AddToolTip,
-                TranslatesAutoresizingMaskIntoConstraints = false
-            };
+            _addButton = new BarTextButton();
+            _addButton.Title = KeyValueTableEntryOption.AddButtonTitle;
+            _addButton.ToolTip = KeyValueTableEntryOption.AddToolTip;
             _addButton.SizeToFit();
             _addButton.Activated += OnAddClicked;
-            _removeButton = new NSButton
-            {
-                BezelStyle = NSBezelStyle.RoundRect,
-                Title = KeyValueTableEntryOption.RemoveButtonTitle,
-                ToolTip = KeyValueTableEntryOption.RemoveToolTip,
-                TranslatesAutoresizingMaskIntoConstraints = false
-            };
+
+            _removeButton = new BarTextButton();
+            _removeButton.Title = KeyValueTableEntryOption.RemoveButtonTitle;
+            _removeButton.ToolTip = KeyValueTableEntryOption.RemoveToolTip;
             _removeButton.SizeToFit();
             _removeButton.Activated += OnRemoveClicked;
             _optionView.AddSubview(_addButton);

--- a/src/VisualStudioUI.VSMac/Options/KeyValueTypeTableOptionVSMac.cs
+++ b/src/VisualStudioUI.VSMac/Options/KeyValueTypeTableOptionVSMac.cs
@@ -104,33 +104,21 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
             };
 
             _optionView.AddSubview(scrolledView);
-            _addButton = new NSButton
-            {
-                BezelStyle = NSBezelStyle.RoundRect,
-                Title = KeyValueTypeTableOption.AddButtonTitle,
-                ToolTip = KeyValueTypeTableOption.AddToolTip,
-                TranslatesAutoresizingMaskIntoConstraints = false
-            };
+            _addButton = new BarTextButton();
+            _addButton.Title = KeyValueTypeTableOption.AddButtonTitle;
+            _addButton.ToolTip = KeyValueTypeTableOption.AddToolTip;
             _addButton.SizeToFit();
             _addButton.Activated += OnAddClicked;
 
-            _removeButton = new NSButton
-            {
-                BezelStyle = NSBezelStyle.RoundRect,
-                Title = KeyValueTypeTableOption.RemoveButtonTitle,
-                ToolTip = KeyValueTypeTableOption.RemoveToolTip,
-                TranslatesAutoresizingMaskIntoConstraints = false
-            };
+            _removeButton = new BarTextButton();
+            _removeButton.Title = KeyValueTypeTableOption.RemoveButtonTitle;
+            _removeButton.ToolTip = KeyValueTypeTableOption.RemoveToolTip;
             _removeButton.SizeToFit();
             _removeButton.Activated += OnRemoveClicked;
 
-            _editButton = new NSButton
-            {
-                BezelStyle = NSBezelStyle.RoundRect,
-                Title = KeyValueTypeTableOption.EditButtonTitle,
-                ToolTip = KeyValueTypeTableOption.EditToolTip,
-                TranslatesAutoresizingMaskIntoConstraints = false
-            };
+            _editButton = new BarTextButton();
+            _editButton.Title = KeyValueTypeTableOption.EditButtonTitle;
+            _editButton.ToolTip = KeyValueTypeTableOption.EditToolTip;
             _editButton.SizeToFit();
             _editButton.Activated += OnEditClicked;
 


### PR DESCRIPTION
Now these buttons use the BarTextButton class,
same as the VSMac IDE uses, in order to set
wider margins on the left/right and a minimum
width, matching design guidelines.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1496336

![image](https://user-images.githubusercontent.com/245892/157824472-d67740f6-8641-4a73-9d63-f733c8fca47b.png)

![image](https://user-images.githubusercontent.com/245892/157824536-f5e79cb8-c9c7-4f55-b72c-37f541ede3ef.png)
