### PR TITLE
By default, make cards fill available width now

### DIFF
--- a/src/VisualStudioUI.VSMac/Options/OptionCardVSMac.cs
+++ b/src/VisualStudioUI.VSMac/Options/OptionCardVSMac.cs
@@ -33,18 +33,6 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
                 TranslatesAutoresizingMaskIntoConstraints = false
             };
 
-            var cardWidthConstraint = cardView.WidthAnchor.ConstraintEqualTo(640f);
-            cardWidthConstraint.Active = true;
-            //var cardHeightConstraint = cardView.HeightAnchor.ConstraintEqualTo (367f);
-            //cardHeightConstraint.Active = true;
-
-            /*
-            cardView.TrailingAnchor.ConstraintEqualTo (this.TrailingAnchor, 0f).Active = true;
-            cardView.LeadingAnchor.ConstraintEqualTo (this.LeadingAnchor, 0f).Active = true;
-            cardView.BottomAnchor.ConstraintEqualTo (this.BottomAnchor, 0f).Active = true;
-            cardView.TopAnchor.ConstraintEqualTo (this.TopAnchor, 0f).Active = true;
-            */
-
             // View:     background
             var background = new NSBox();
             background.BoxType = NSBoxType.NSBoxCustom;
@@ -56,14 +44,6 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
             background.TranslatesAutoresizingMaskIntoConstraints = false;
 
             cardView.AddSubview(background);
-            /*
-            var backgroundWidthConstraint = background.WidthAnchor.ConstraintEqualTo (640f);
-            backgroundWidthConstraint.Priority = (System.Int32)NSLayoutPriority.DefaultLow;
-            backgroundWidthConstraint.Active = true;
-            var backgroundHeightConstraint = background.HeightAnchor.ConstraintEqualTo (367f);
-            backgroundHeightConstraint.Priority = (System.Int32)NSLayoutPriority.DefaultLow;
-            backgroundHeightConstraint.Active = true;
-            */
 
             background.TrailingAnchor.ConstraintEqualTo(cardView.TrailingAnchor, 0f).Active = true;
             background.LeadingAnchor.ConstraintEqualTo(cardView.LeadingAnchor, 0f).Active = true;

--- a/src/VisualStudioUI.VSMac/Options/OptionCardsVSMac.cs
+++ b/src/VisualStudioUI.VSMac/Options/OptionCardsVSMac.cs
@@ -33,6 +33,12 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
             cardsStack.Orientation = NSUserInterfaceLayoutOrientation.Vertical;
             cardsStack.Distribution = NSStackViewDistribution.Fill;
 
+            NSLayoutConstraint widthConstraint;
+            if (OptionCards.UseFixedWidth)
+                widthConstraint = cardsStack.WidthAnchor.ConstraintEqualTo(680f);
+            else widthConstraint = cardsStack.WidthAnchor.ConstraintGreaterThanOrEqualTo(680f);
+            widthConstraint.Active = true;
+
             foreach (OptionCard card in OptionCards.Cards)
             {
                 NSView cardView = ((OptionCardVSMac) card.Platform).View;

--- a/src/VisualStudioUI/Options/OptionCards.cs
+++ b/src/VisualStudioUI/Options/OptionCards.cs
@@ -8,9 +8,19 @@ namespace Microsoft.VisualStudioUI.Options
 
         public OptionCardsPlatform Platform { get; }
 
-        public OptionCards()
+        /// <summary>
+        /// Indicates whether the cards should expand width wise to fill available space
+        /// (that's the desired UI when in a dialog) or if they should
+        /// have a fixed width (that's the desired UI when in a document window,
+        /// where the width is normally much wider and taking it all can look odd).
+        /// Even if UseFixedWidth is off, cards still have a minimum width.
+        /// </summary>
+        public bool UseFixedWidth { get; }
+
+        public OptionCards(bool useFixedWidth = false)
         {
             Platform = OptionFactoryPlatform.Instance.CreateOptionCardsPlatform(this);
+            UseFixedWidth = useFixedWidth;
         }
 
         public IReadOnlyList<OptionCard> Cards => _cards;


### PR DESCRIPTION
The desired UI on Mac is:
- For cards that are in a dialog (e.g. project and app
preferences - most of them) make the card fill available
width (with a minimum). If the dialog is resized, the
card grows horizontally.
- For cards that are in a doc windows (e.g. Android
manifest and iOS PList), give them a fixed width since
the doc window can be very wide (esp. with a wide
screen monitor) and filling it all looks funny.