### PR TITLE
Used MultilineButton for checkbox word wrap

### DIFF
--- a/src/VisualStudioUI.VSMac/Options/CheckBoxOptionVSMac.cs
+++ b/src/VisualStudioUI.VSMac/Options/CheckBoxOptionVSMac.cs
@@ -8,7 +8,7 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
 {
     public class CheckBoxOptionVSMac : OptionWithLeftLabelVSMac
     {
-        private NSButton? _button;
+        private MultilineButton? _button;
 
         public CheckBoxOptionVSMac(CheckBoxOption option) : base(option)
         {
@@ -24,27 +24,19 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
                 {
                     ViewModelProperty<bool> property = CheckBoxOption.Property;
 
-                    _button = NSButton.CreateCheckbox(CheckBoxOption.ButtonLabel, CheckBoxSelected);
-                    _button.SetButtonType(NSButtonType.Radio);
-                    _button.ControlSize = NSControlSize.Regular;
+                    _button = new MultilineButton();
+                    _button.SetButtonType(NSButtonType.Switch);
+                    _button.primaryControl.Activated += (o, args) => CheckBoxSelected();
+
+                    _button.primaryControl.ControlSize = NSControlSize.Regular;
                     _button.Title = CheckBoxOption.ButtonLabel;
-                    _button.TranslatesAutoresizingMaskIntoConstraints = false;
-                    _button.State = CheckBoxOption.Property.Value ? NSCellStateValue.On : NSCellStateValue.Off;
-                    _button.LineBreakMode = NSLineBreakMode.TruncatingTail;
-                    if (_button.Title.Length > 97)
-                    {
-                        _button.Font = NSFont.SystemFontOfSize(10);
-                    }
-                    else if (_button.Title.Length > 80)
-                    {
-                        _button.Font = NSFont.SystemFontOfSize(NSFont.SmallSystemFontSize);
-                    } else
-                    {
-                        _button.Font = NSFont.SystemFontOfSize(NSFont.SystemFontSize);
-                    }
+                    _button.primaryControl.AccessibilityTitle = CheckBoxOption.ButtonLabel;
+                    _button.primaryControl.State = CheckBoxOption.Property.Value ? NSCellStateValue.On : NSCellStateValue.Off;
+                    _button.secondaryLabel.WidthAnchor.ConstraintLessThanOrEqualTo(500f).Active = true;
+
                     property.PropertyChanged += delegate
                     {
-                        _button.State = CheckBoxOption.Property.Value ? NSCellStateValue.On : NSCellStateValue.Off;
+                        _button.primaryControl.State = CheckBoxOption.Property.Value ? NSCellStateValue.On : NSCellStateValue.Off;
                     };
                 }
 
@@ -62,7 +54,7 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
 
         private void CheckBoxSelected()
         {
-            CheckBoxOption.Property.Value = (_button?.State == NSCellStateValue.On) ? true : false;
+            CheckBoxOption.Property.Value = (_button?.primaryControl.State == NSCellStateValue.On) ? true : false;
         }
     }
 }

--- a/src/VisualStudioUI.VSMac/Options/CustomStackView.cs
+++ b/src/VisualStudioUI.VSMac/Options/CustomStackView.cs
@@ -1,0 +1,25 @@
+using AppKit;
+
+/// <summary>
+/// This file is copied & simplified from NSCustomStackView.cs in VSMac
+/// </summary>
+
+namespace Microsoft.VisualStudioUI.VSMac.Options
+{
+    public class CustomStackView : AppKit.NSStackView
+    {
+        public override bool IsFlipped => true;
+
+        public CustomStackView(AppKit.NSUserInterfaceLayoutOrientation orientation = NSUserInterfaceLayoutOrientation.Vertical, float spacing = 10)
+        {
+            TranslatesAutoresizingMaskIntoConstraints = false;
+            Orientation = orientation;
+            Spacing = spacing;
+            Distribution = NSStackViewDistribution.Fill;
+            if (orientation == NSUserInterfaceLayoutOrientation.Vertical)
+                Alignment = NSLayoutAttribute.Leading;
+            else
+                Alignment = NSLayoutAttribute.CenterY;
+        }
+    }
+}

--- a/src/VisualStudioUI.VSMac/Options/NSCustomViews.cs
+++ b/src/VisualStudioUI.VSMac/Options/NSCustomViews.cs
@@ -1,0 +1,85 @@
+using AppKit;
+
+/// <summary>
+/// This file is copied & simplified from NSCustomViews.cs in VSMac
+/// </summary>
+
+namespace Microsoft.VisualStudioUI.VSMac.Options
+{
+    internal class MultilineButton : CustomStackView
+    {
+        readonly internal NSButton primaryControl;
+        readonly internal NSLabel secondaryLabel;
+
+        public bool Enabled
+        {
+            get => primaryControl.Enabled;
+            set => primaryControl.Enabled = value;
+        }
+
+        public string Title
+        {
+            get => secondaryLabel.StringValue;
+            set => secondaryLabel.StringValue = value;
+        }
+
+        public bool AllowsMixedState
+        {
+            get => primaryControl.AllowsMixedState;
+            set => primaryControl.AllowsMixedState = value;
+        }
+
+        public string ControlAccessibilityHelp
+        {
+            get => primaryControl.AccessibilityHelp;
+            set => primaryControl.AccessibilityHelp = value ?? string.Empty;
+        }
+
+        public MultilineButton() : base(NSUserInterfaceLayoutOrientation.Horizontal, 5)
+        {
+            Alignment = NSLayoutAttribute.Top;
+
+            primaryControl = new AppKit.NSButton()
+            {
+                TranslatesAutoresizingMaskIntoConstraints = false,
+                Title = string.Empty
+            };
+            this.AddArrangedSubview(primaryControl);
+
+            primaryControl.SetContentHuggingPriorityForOrientation((int)NSLayoutPriority.DefaultHigh, NSLayoutConstraintOrientation.Horizontal);
+
+            secondaryLabel = new NSLabel();
+            this.AddArrangedSubview(secondaryLabel);
+            secondaryLabel.Cell.AccessibilityElement = false;
+            secondaryLabel.LineBreakMode = NSLineBreakMode.ByWordWrapping;
+            secondaryLabel.SetContentCompressionResistancePriority((int)NSLayoutPriority.DefaultLow, NSLayoutConstraintOrientation.Horizontal);
+
+            // Align the image centerY to the centerY of the first line of text
+            var offset = secondaryLabel.Font.CapHeight / 2;
+            primaryControl.CenterYAnchor.ConstraintEqualTo(secondaryLabel.FirstBaselineAnchor, -offset).Active = true;
+        }
+
+        internal void SetButtonType(NSButtonType type)
+        {
+            primaryControl.SetButtonType(type);
+        }
+    }
+
+    public class NSLabel : NSTextField
+	{
+		public NSLabel (string value = null)
+		{
+			Editable = false;
+			Bordered = false;
+			Bezeled = false;
+			DrawsBackground = false;
+			Selectable = false;
+			TranslatesAutoresizingMaskIntoConstraints = false;
+
+			if (!string.IsNullOrEmpty(value))
+            {
+				StringValue = value;
+            }
+		}
+	}
+}


### PR DESCRIPTION
Switch to using MultilineButton, copied/adapted from
similar code in VSMac, so that the label for a checkbox
can word wrap if too long.

Fixes AB#1389630