### PR TITLE
Set the accessibility title for string list

### DIFF
--- a/src/VisualStudioUI.VSMac/Options/StringListOptionVSMac.cs
+++ b/src/VisualStudioUI.VSMac/Options/StringListOptionVSMac.cs
@@ -70,6 +70,7 @@ namespace Microsoft.VisualStudioUI.VSMac.Options
             };
             _tableView.GridStyleMask = NSTableViewGridStyle.DashedHorizontalGridLine;
             _tableView.AddColumn(new NSTableColumn());
+            SetAccessibilityTitleToLabel(_tableView);
 
             var scrolledView = new NSScrollView()
             {


### PR DESCRIPTION
For the StringList option type, set the accessibility title
for the table to match the label.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1504572